### PR TITLE
More results

### DIFF
--- a/backend/routes/pages.js
+++ b/backend/routes/pages.js
@@ -22,7 +22,7 @@ router.get('/query/:terms', function(req, res, next) {
         Page.esClient.search({
           "body": {
             "from" : start,
-            "size" : 30,
+            "size" : 20,
             "query": {
               "query_string": {
                 query: req.params.terms + "~",

--- a/backend/routes/pages.js
+++ b/backend/routes/pages.js
@@ -18,8 +18,11 @@ router.get('/query/:terms', function(req, res, next) {
     validateUser(req, res, doSearch);
 
     function doSearch(user){
+        var start = req.query.from || 0;
         Page.esClient.search({
           "body": {
+            "from" : start,
+            "size" : 30,
             "query": {
               "query_string": {
                 query: req.params.terms + "~",


### PR DESCRIPTION
This enables more results to be loaded in the backend. The default size is 20, and you can paginate using the ```from``` parameter.

Closes #57 